### PR TITLE
Remove usage of get_descriptor

### DIFF
--- a/data_access_api.py
+++ b/data_access_api.py
@@ -33,9 +33,6 @@ class DataAccessApi:
     Class that provides wrapper functionality for the DataCube.
     """
 
-    dc = None
-    api = None
-
     # defaults for all the required fields.
     product_default = 'ls7_ledaps'
     platform_default = 'LANDSAT_7'

--- a/data_access_api.py
+++ b/data_access_api.py
@@ -192,7 +192,8 @@ class DataAccessApi:
         return {
             'lat_extents': (lat_min, lat_max),
             'lon_extents': (lon_min, lon_max),
-            'time_extents': (dataset.time[0], dataset.time[-1]),
+            'time_extents': (dataset.time[0].values.astype('M8[ms]').tolist(),
+                             dataset.time[-1].values.astype('M8[ms]').tolist()),
             'scene_count': dataset.time.size,
             'pixel_count': dataset.geobox.shape[0] * dataset.geobox.shape[1],
             # TODO: is 'tile_count' needed?
@@ -226,7 +227,7 @@ class DataAccessApi:
         if not dataset:
             return []
 
-        return dataset.time
+        return dataset.time.values.astype('M8[ms]').tolist()
 
     def get_datacube_metadata(self, platform, product):
         """

--- a/data_access_api.py
+++ b/data_access_api.py
@@ -22,24 +22,6 @@
 
 # datacube imports.
 import datacube
-from datacube.api import *
-
-# basic stuff.
-from collections import defaultdict
-import time
-from datetime import datetime
-import json
-
-# dc data comes out as xray arrays
-import xarray as xr
-import xarray.ufuncs
-
-# gdal related stuff.
-import gdal
-from gdalconst import *
-
-# np for arrays
-import numpy as np
 
 # Author: AHDS
 # Creation date: 2016-06-23

--- a/data_access_api.py
+++ b/data_access_api.py
@@ -51,7 +51,8 @@ class DataAccessApi:
     """
 
     def get_dataset_by_extent(self, product, product_type=None, platform=None, time=None,
-                              longitude=None, latitude=None, measurements=None, output_crs=None, resolution=None):
+                              longitude=None, latitude=None, measurements=None, output_crs=None,
+                              resolution=None, crs=None, dask_chunks=None):
         """
         Gets and returns data based on lat/long bounding box inputs.
         All params are optional. Leaving one out will just query the dc without it, (eg leaving out
@@ -64,9 +65,11 @@ class DataAccessApi:
             time (tuple): A tuple consisting of the start time and end time for the dataset.
             longitude (tuple): A tuple of floats specifying the min,max longitude bounds.
             latitude (tuple): A tuple of floats specifying the min,max latitutde bounds.
+            crs (string): CRS lat/lon bounds are specified in, defaults to WGS84.
             measurements (list): A list of strings that represents all measurements.
             output_crs (string): Determines reprojection of the data before its returned
             resolution (tuple): A tuple of min,max ints to determine the resolution of the data.
+            dask_chunks (dict): Lazy loaded array block sizes, not lazy loaded by default.
 
         Returns:
             data (xarray): dataset with the desired data.
@@ -83,9 +86,11 @@ class DataAccessApi:
         if longitude is not None and latitude is not None:
             query['longitude'] = longitude
             query['latitude'] = latitude
+        if crs is not None:
+            query['crs'] = crs
 
         data = self.dc.load(product=product, measurements=measurements,
-                       output_crs=output_crs, resolution=resolution, **query)
+                            output_crs=output_crs, resolution=resolution, dask_chunks=dask_chunks, **query)
         # data = self.dc.load(product=product, product_type=product_type, platform=platform, time=time, longitude=longitude,
         # latitude=latitude, measurements=measurements, output_crs=output_crs,
         # resolution=resolution)

--- a/data_access_api.py
+++ b/data_access_api.py
@@ -22,11 +22,13 @@
 
 # datacube imports.
 import datacube
+from datacube.api import GridWorkflow
 
 # Author: AHDS
 # Creation date: 2016-06-23
 # Modified by:
 # Last modified date: 2016-08-05
+
 
 class DataAccessApi:
     """
@@ -43,8 +45,6 @@ class DataAccessApi:
         # fetching.
         # hardcoded config location. could parameterize.
         self.dc = datacube.Datacube(config='/home/localuser/Datacube/data_cube_ui/config/.datacube.conf')
-        #self.dc = datacube.Datacube()
-        self.api = datacube.api.API(datacube=self.dc)
 
     """
     query params are defined in datacube.api.query
@@ -91,14 +91,10 @@ class DataAccessApi:
 
         data = self.dc.load(product=product, measurements=measurements,
                             output_crs=output_crs, resolution=resolution, dask_chunks=dask_chunks, **query)
-        # data = self.dc.load(product=product, product_type=product_type, platform=platform, time=time, longitude=longitude,
-        # latitude=latitude, measurements=measurements, output_crs=output_crs,
-        # resolution=resolution)
         return data
 
-
     def get_dataset_tiles(self, product, product_type=None, platform=None, time=None,
-                              longitude=None, latitude=None, measurements=None, output_crs=None, resolution=None):
+                          longitude=None, latitude=None, measurements=None, output_crs=None, resolution=None):
         """
         Gets and returns data based on lat/long bounding box inputs.
         All params are optional. Leaving one out will just query the dc without it, (eg leaving out
@@ -131,12 +127,12 @@ class DataAccessApi:
             query['longitude'] = longitude
             query['latitude'] = latitude
 
-        #set up the grid workflow
+        # set up the grid workflow
         gw = GridWorkflow(self.dc.index, product=product)
 
-        #dict of tiles.
+        # dict of tiles.
         request_tiles = gw.list_cells(product=product, measurements=measurements,
-                       output_crs=output_crs, resolution=resolution, **query)
+                                      output_crs=output_crs, resolution=resolution, **query)
 
         """
         tile_def = defaultdict(dict)
@@ -151,7 +147,7 @@ class DataAccessApi:
             tile = tile_def[key]['request']
             data_tiles[key[0]] = gw.load(key[0], tile)
         """
-        #cells now return stacked xarrays of data.
+        # cells now return stacked xarrays of data.
         data_tiles = {}
         for tile_key in request_tiles:
             tile = request_tiles[tile_key]
@@ -159,14 +155,13 @@ class DataAccessApi:
 
         return data_tiles
 
-
     def get_scene_metadata(self, platform, product, longitude=None, latitude=None, crs=None, time=None):
         """
         Gets a descriptor based on a request.
 
         Args:
             platform (string): Platform for which data is requested
-            product_type (string): Product type for which data is requested
+            product (string): The name of the product associated with the desired dataset.
             longitude (tuple): Tuple of min,max floats for longitude
             latitude (tuple): Tuple of min,max floats for latitutde
             crs (string): Describes the coordinate system of params lat and long
@@ -210,7 +205,7 @@ class DataAccessApi:
 
         Args:
             platform (string): Platform for which data is requested
-            product_type (string): Product type for which data is requested
+            product (string): The name of the product associated with the desired dataset.
             longitude (tuple): Tuple of min,max floats for longitude
             latitude (tuple): Tuple of min,max floats for latitutde
             crs (string): Describes the coordinate system of params lat and long


### PR DESCRIPTION
datacube.api.API interface is not maintained anymore and is going to be deprecated and removed in the future.

This pull request attempts to duplicate existing functionality by using Datacube.load lazy array functionaity.

Datacube.load does not provide information on what tile files/storage units are read to retrieve the data, so some information cannot be provided. I could not find any usage of that information in the existing codebase, so this should have no visible effect. Let me know if it is not so and I'll see what can be done