### PR TITLE
Correction of datetime list precision Issue

### DIFF
--- a/data_cube_utilities/data_access_api.py
+++ b/data_cube_utilities/data_access_api.py
@@ -24,6 +24,7 @@ import datacube
 from datacube.api import GridWorkflow
 import xarray as xr
 import numpy as np
+import datetime
 from datetime import date
 
 
@@ -260,7 +261,10 @@ class DataAccessApi:
             if not dataset:
                 continue
 
-            dates += dataset.time.values.astype('M8[ms]').tolist()
+            #dates += dataset.time.values.astype('M8[ms]').tolist()
+            dates += [ datetime.datetime.utcfromtimestamp(
+                (dt - np.datetime64('1970-01-01T00:00:00Z')) / np.timedelta64(1, 's') )
+                for dt in dataset.time.values ]
 
         return dates
 


### PR DESCRIPTION
In respose to https://github.com/ceos-seo/data_cube_utilities/issues/4

The datetime list generated by function above is precise to milliseconds.

https://github.com/ceos-seo/data_cube_ui/blob/14fa410b7e8fc9d08ba2029f23dd07f9d83ff1d9/apps/custom_mosaic_tool/tasks.py#L279

Precision needed to be in microseconds for above calling function to work correctly
This results in return of empty datasets more than half the time.